### PR TITLE
Add findmin, findmax, argmin, and argmax

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "NaNMath"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 repo = "https://github.com/mlubin/NaNMath.jl.git"
 authors = ["Miles Lubin"]
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "NaNMath"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 repo = "https://github.com/mlubin/NaNMath.jl.git"
 authors = ["Miles Lubin"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ sum
 maximum
 minimum
 extrema
+argmax
+argmin
+findmax
+findmin
 mean
 median
 var

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -407,12 +407,16 @@ findmax(f, x) = _findminmax(Base.isless, f, x)
 findmax(x) = findmax(identity, x)
 
 function _findminmax_op(cmp)
-    return (x1_i1, x2_i2) -> begin
-        x1 = first(x1_i1)
-        x1 === missing && return x1_i1
-        x2 = first(x2_i2)
-        x2 === missing && return x2_i2
-        return ifelse((x1 isa Number && isnan(x2)) || !cmp(x1, x2), x1_i1, x2_i2)
+    return (xleft_and_index, xright_and_index) -> begin
+        xleft = first(xleft_and_index)
+        xleft === missing && return xleft_and_index
+        xright = first(xright_and_index)
+        xright === missing && return xright_and_index
+        return ifelse(
+            (xleft isa Number && isnan(xright)) || !cmp(xleft, xright),
+            xleft_and_index,
+            xright_and_index,
+        )
     end
 end
 

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -412,7 +412,7 @@ function _findminmax_op(cmp)
         x1 === missing && return x1_i1
         x2 = first(x2_i2)
         x2 === missing && return x2_i2
-        return ifelse(isnan(x2) || x1 == x2 || cmp(x2, x1), x1_i1, x2_i2)
+        return ifelse((x1 isa Number && isnan(x2)) || !cmp(x1, x2), x1_i1, x2_i2)
     end
 end
 

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -358,14 +358,15 @@ end
     NaNMath.findmin([f,] domain) -> (f(x), index)
 
 ##### Args:
-* `f`: a function applied to the values in `domain`
-* `domain`: A non-empty iterable of floating point numbers or `Missing`.
+* `f`: a function applied to the values in `domain` (defaulting to `identity`)
+* `domain`: A non-empty iterable such that the codomain (outputs of `f` applied to `domain`)
+are floating point numbers or `missing`
 
 ##### Returns:
-* Returns a pair of a value in the codomain (outputs of `f`, defaulting to `identity`) and
-the index of the corresponding value in the `domain` (inputs to `f`) such that `f(x)` is
-minimized. If there are multiple minimal points, then the first one will be returned. `NaN`s
-are treated as greater than all other values.
+* Returns a pair of a value in the codomain and the index of the corresponding value in the
+`domain` (inputs to `f`) such that `f(x)` is minimized. If there are multiple minimal
+points, then the first one will be returned. `NaN`s are treated as greater than all other
+values.
 
 ##### Examples:
 ```julia
@@ -384,14 +385,15 @@ findmin(x) = findmin(identity, x)
     NaNMath.findmax([f,] domain) -> (f(x), index)
 
 ##### Args:
-* `f`: a function applied to the values in `domain`
-* `domain`: A non-empty iterable of floating point numbers or `Missing`.
+* `f`: a function applied to the values in `domain` (defaulting to `identity`)
+* `domain`: A non-empty iterable such that the codomain (outputs of `f` applied to `domain`)
+are floating point numbers or `missing`
 
 ##### Returns:
-* Returns a pair of a value in the codomain (outputs of `f`, defaulting to `identity`) and
-the index of the corresponding value in the `domain` (inputs to `f`) such that `f(x)` is
-maximized. If there are multiple minimal points, then the first one will be returned. `NaN`s
-are treated as less than all other values.
+* Returns a pair of a value in the codomain and the index of the corresponding value in the
+`domain` (inputs to `f`) such that `f(x)` is maximized. If there are multiple maximal
+points, then the first one will be returned. `NaN`s are treated as less than all other
+values.
 
 ##### Examples:
 ```julia
@@ -431,12 +433,13 @@ end
 
 ##### Args:
 * `f`: A function applied to the values of `domain`
-* `domain`: A non-empty iterable of floating point numbers or `Missing`.
+* `domain`: A non-empty iterable such that the codomain (outputs of `f` applied to `domain`)
+are floating point numbers or `missing`
 
 ##### Returns:
-* Returns a value `x` in the domain of `f` for which `f(x)` is minimised. If there are
+* Returns a value `x` in the domain of `f` for which `f(x)` is minimized. If there are
 multiple minimal values for `f(x)`, then the first one will be found. `NaN`s are treated as
-less than all other values.
+greater than all other values.
 
 ##### Examples:
 ```julia
@@ -450,7 +453,7 @@ julia> NaNMath.argmin(identity, [7, 1, 1, NaN])
     NaNMath.argmin(itr) -> key
 
 ##### Args:
-* `itr`: A non-empty iterable of floating point numbers or `Missing`.
+* `itr`: A non-empty iterable of floating point numbers or `missing`.
 
 ##### Returns:
 * Returns the index or key of the minimal element in `itr`. If there are multiple
@@ -477,12 +480,13 @@ argmin(f, x) = mapfoldl(x -> (f(x), x), _findminmax_op(Base.isgreater), x)[2]
 
 ##### Args:
 * `f`: A function applied to the values of `domain`
-* `domain`: A non-empty iterable of floating point numbers or `Missing`.
+* `domain`: A non-empty iterable such that the codomain (outputs of `f` applied to `domain`)
+are floating point numbers or `missing`
 
 ##### Returns:
-* Returns a value `x` in the domain of `f` for which `f(x)` is maximised. If there are
-multiple minimal values for `f(x)`, then the first one will be found. `NaN`s are treated as
-greater than all other values.
+* Returns a value `x` in the domain of `f` for which `f(x)` is maximized. If there are
+multiple maximal values for `f(x)`, then the first one will be found. `NaN`s are treated as
+less than all other values.
 
 ##### Examples:
 ```julia
@@ -496,7 +500,7 @@ julia> NaNMath.argmax(identity, [7, 1, 1, NaN])
     NaNMath.argmax(itr) -> key
 
 ##### Args:
-* `itr`: A non-empty iterable of floating point numbers or `Missing`.
+* `itr`: A non-empty iterable of floating point numbers or `missing`.
 
 ##### Returns:
 * Returns the index or key of the maximal element in `itr`. If there are multiple

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -417,7 +417,7 @@ function _findminmax_op(cmp)
 end
 
 function _findminmax(cmp, f, x)
-    return mapreduce(_findminmax_op(cmp), pairs(x)) do (k, xk)
+    return mapfoldl(_findminmax_op(cmp), pairs(x)) do (k, xk)
         return f(xk), k
     end
 end

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -366,7 +366,7 @@ are floating point numbers or `missing`
 * Returns a pair of a value in the codomain and the index of the corresponding value in the
 `domain` (inputs to `f`) such that `f(x)` is minimized. If there are multiple minimal
 points, then the first one will be returned. `NaN`s are treated as greater than all other
-values.
+values, while `missing` is treated as less than all other values.
 
 ##### Examples:
 ```julia
@@ -393,7 +393,7 @@ are floating point numbers or `missing`
 * Returns a pair of a value in the codomain and the index of the corresponding value in the
 `domain` (inputs to `f`) such that `f(x)` is maximized. If there are multiple maximal
 points, then the first one will be returned. `NaN`s are treated as less than all other
-values.
+values, while `missing` is treated as greater than all other values.
 
 ##### Examples:
 ```julia
@@ -439,7 +439,7 @@ are floating point numbers or `missing`
 ##### Returns:
 * Returns a value `x` in the domain of `f` for which `f(x)` is minimized. If there are
 multiple minimal values for `f(x)`, then the first one will be found. `NaN`s are treated as
-greater than all other values.
+greater than all other values, while `missing` is treated as less than all other values.
 
 ##### Examples:
 ```julia
@@ -486,7 +486,7 @@ are floating point numbers or `missing`
 ##### Returns:
 * Returns a value `x` in the domain of `f` for which `f(x)` is maximized. If there are
 multiple maximal values for `f(x)`, then the first one will be found. `NaN`s are treated as
-less than all other values.
+less than all other values, while `missing` is treated as greater than all other values.
 
 ##### Examples:
 ```julia

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -422,4 +422,96 @@ function _findminmax(cmp, f, x)
     end
 end
 
+"""
+    NaNMath.argmin(f, domain) -> x
+
+##### Args:
+* `f`: A function applied to the values of `domain`
+* `domain`: A non-empty iterable of floating point numbers or `Missing`.
+
+##### Returns:
+* Returns a value `x` in the domain of `f` for which `f(x)` is minimised. If there are
+multiple minimal values for `f(x)`, then the first one will be found. `NaN`s are treated as
+less than all other values.
+
+##### Examples:
+```julia
+julia> NaNMath.argmin(abs, [1., -1., -2., 2., NaN])
+1.0
+
+julia> NaNMath.argmin(identity, [7, 1, 1, NaN])
+1.0
+```
+
+    NaNMath.argmin(itr) -> key
+
+##### Args:
+* `itr`: A non-empty iterable of floating point numbers or `Missing`.
+
+##### Returns:
+* Returns the index or key of the minimal element in `itr`. If there are multiple
+minimal elements, then the first one will be returned
+
+##### Examples:
+```julia
+julia> NaNMath.argmin([7, 1, 1, NaN])
+2
+
+julia> NaNMath.argmin([1.0 2; 3 NaN])
+CartesianIndex(1, 1)
+
+julia> NaNMath.argmin(Dict("x" => 1.0, "y" => -1, "z" => NaN))
+"y"
+```
+"""
+function argmin end
+argmin(x) = findmin(identity, x)[2]
+argmin(f, x) = mapfoldl(x -> (f(x), x), _findminmax_op(Base.isgreater), x)[2]
+
+"""
+    NaNMath.argmax(f, domain) -> x
+
+##### Args:
+* `f`: A function applied to the values of `domain`
+* `domain`: A non-empty iterable of floating point numbers or `Missing`.
+
+##### Returns:
+* Returns a value `x` in the domain of `f` for which `f(x)` is maximised. If there are
+multiple minimal values for `f(x)`, then the first one will be found. `NaN`s are treated as
+greater than all other values.
+
+##### Examples:
+```julia
+julia> NaNMath.argmax(abs, [1., -1., -2., NaN])
+2.0
+
+julia> NaNMath.argmax(identity, [7, 1, 1, NaN])
+7.0
+```
+
+    NaNMath.argmax(itr) -> key
+
+##### Args:
+* `itr`: A non-empty iterable of floating point numbers or `Missing`.
+
+##### Returns:
+* Returns the index or key of the maximal element in `itr`. If there are multiple
+maximal elements, then the first one will be returned
+
+##### Examples:
+```julia
+julia> NaNMath.argmax([7, 1, 1, NaN])
+1
+
+julia> NaNMath.argmax([1.0 2; 3 NaN])
+CartesianIndex(2, 1)
+
+julia> NaNMath.argmax(Dict("x" => 1.0, "y" => -1, "z" => NaN))
+"x"
+```
+"""
+function argmax end
+argmax(x) = findmax(identity, x)[2]
+argmax(f, x) = mapfoldl(x -> (f(x), x), _findminmax_op(Base.isless), x)[2]
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,22 +72,24 @@ using Test
 @test NaNMath.max(NaN, NaN, 0.0, 1.0) == 1.0
 
 @testset "findmin/findmax" begin
-    xvals = [
-        [1., 2., 3., 3., 1.],
-        [missing, missing],
-        [missing, 1.0],
-        [1.0, missing],
-        (1., 2, 3., 3, 1),
-        (x=1, y=3, z=-4, w=-2),
-        Dict(:a => 1.0, :b => 1.0, :d => 3.0, :c => 2.0),
-    ]
-    VERSION ≥ v"1.7" && @testset for x in xvals
-        @test NaNMath.findmin(x) === findmin(x)
-        @test NaNMath.findmax(x) === findmax(x)
-        @test NaNMath.findmin(identity, x) === findmin(identity, x)
-        @test NaNMath.findmax(identity, x) === findmax(identity, x)
-        @test NaNMath.findmin(sin, x) === findmin(sin, x)
-        @test NaNMath.findmax(sin, x) === findmax(sin, x)
+    if VERSION ≥ v"1.7"
+        xvals = [
+            [1., 2., 3., 3., 1.],
+            [missing, missing],
+            [missing, 1.0],
+            [1.0, missing],
+            (1., 2, 3., 3, 1),
+            (x=1, y=3, z=-4, w=-2),
+            Dict(:a => 1.0, :b => 1.0, :d => 3.0, :c => 2.0),
+        ]
+        @testset for x in xvals
+            @test NaNMath.findmin(x) === findmin(x)
+            @test NaNMath.findmax(x) === findmax(x)
+            @test NaNMath.findmin(identity, x) === findmin(identity, x)
+            @test NaNMath.findmax(identity, x) === findmax(identity, x)
+            @test NaNMath.findmin(sin, x) === findmin(sin, x)
+            @test NaNMath.findmax(sin, x) === findmax(sin, x)
+        end
     end
     x = [7, 7, NaN, 1, 1, NaN]
     @test NaNMath.findmin(x) === (1.0, 4)
@@ -129,22 +131,24 @@ using Test
 end
 
 @testset "argmin/argmax" begin
-    xvals = [
-        [1., 2., 3., 3., 1.],
-        [missing, missing],
-        [missing, 1.0],
-        [1.0, missing],
-        (1., 2, 3., 3, 1),
-        (x=1, y=3, z=-4, w=-2),
-        Dict(:a => 1.0, :b => 1.0, :d => 3.0, :c => 2.0),
-    ]
-    VERSION ≥ v"1.7" && @testset for x in xvals
-        @test NaNMath.argmin(x) === argmin(x)
-        @test NaNMath.argmax(x) === argmax(x)
-        @test NaNMath.argmin(identity, x) === argmin(identity, x)
-        @test NaNMath.argmax(identity, x) === argmax(identity, x)
-        x isa Dict || @test NaNMath.argmin(sin, x) === argmin(sin, x)
-        x isa Dict || @test NaNMath.argmax(sin, x) === argmax(sin, x)
+    if VERSION ≥ v"1.7"
+        xvals = [
+            [1., 2., 3., 3., 1.],
+            [missing, missing],
+            [missing, 1.0],
+            [1.0, missing],
+            (1., 2, 3., 3, 1),
+            (x=1, y=3, z=-4, w=-2),
+            Dict(:a => 1.0, :b => 1.0, :d => 3.0, :c => 2.0),
+        ]    
+        @testset for x in xvals
+            @test NaNMath.argmin(x) === argmin(x)
+            @test NaNMath.argmax(x) === argmax(x)
+            @test NaNMath.argmin(identity, x) === argmin(identity, x)
+            @test NaNMath.argmax(identity, x) === argmax(identity, x)
+            x isa Dict || @test NaNMath.argmin(sin, x) === argmin(sin, x)
+            x isa Dict || @test NaNMath.argmax(sin, x) === argmax(sin, x)
+        end
     end
     x = [7, 7, NaN, 1, 1, NaN]
     @test NaNMath.argmin(x) === 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,13 +78,15 @@ using Test
         [missing, 1.0],
         [1.0, missing],
         (1., 2, 3., 3, 1),
+        (x=1, y=3, z=-4, w=-2),
+        Dict(:a => 1.0, :b => 1.0, :d => 3.0, :c => 2.0),
     ]
     @testset for x in xvals
         @test NaNMath.findmin(x) === findmin(x)
-        @test NaNMath.findmin(identity, x) === findmin(identity, x)
-        @test NaNMath.findmin(sin, x) === findmin(sin, x)
         @test NaNMath.findmax(x) === findmax(x)
+        @test NaNMath.findmin(identity, x) === findmin(identity, x)
         @test NaNMath.findmax(identity, x) === findmax(identity, x)
+        @test NaNMath.findmin(sin, x) === findmin(sin, x)
         @test NaNMath.findmax(sin, x) === findmax(sin, x)
     end
     x = [7, 7, NaN, 1, 1, NaN]
@@ -110,6 +112,14 @@ using Test
     @test NaNMath.findmax(identity, x) === (missing, 2)
     @test NaNMath.findmin(sin, x) === (missing, 2)
     @test NaNMath.findmax(sin, x) === (missing, 2)
+
+    x = Dict(:x => 3, :w => 2, :y => -1.0, :z => NaN)
+    @test NaNMath.findmin(x) === (-1.0, :y)
+    @test NaNMath.findmax(x) === (3, :x)
+    @test NaNMath.findmin(identity, x) === (-1.0, :y)
+    @test NaNMath.findmax(identity, x) === (3, :x)
+    @test NaNMath.findmin(-, x) === (-3, :x)
+    @test NaNMath.findmax(-, x) === (1.0, :y)
 end
 
 @testset "argmin/argmax" begin
@@ -119,14 +129,16 @@ end
         [missing, 1.0],
         [1.0, missing],
         (1., 2, 3., 3, 1),
+        (x=1, y=3, z=-4, w=-2),
+        Dict(:a => 1.0, :b => 1.0, :d => 3.0, :c => 2.0),
     ]
     @testset for x in xvals
         @test NaNMath.argmin(x) === argmin(x)
-        @test NaNMath.argmin(identity, x) === argmin(identity, x)
-        @test NaNMath.argmin(sin, x) === argmin(sin, x)
         @test NaNMath.argmax(x) === argmax(x)
+        @test NaNMath.argmin(identity, x) === argmin(identity, x)
         @test NaNMath.argmax(identity, x) === argmax(identity, x)
-        @test NaNMath.argmax(sin, x) === argmax(sin, x)
+        x isa Dict || @test NaNMath.argmin(sin, x) === argmin(sin, x)
+        x isa Dict || @test NaNMath.argmax(sin, x) === argmax(sin, x)
     end
     x = [7, 7, NaN, 1, 1, NaN]
     @test NaNMath.argmin(x) === 4
@@ -151,4 +163,10 @@ end
     @test NaNMath.argmax(identity, x) === missing
     @test NaNMath.argmin(-, x) === missing
     @test NaNMath.argmax(-, x) === missing
+
+    x = Dict(:x => 3, :w => 2, :z => -1.0, :y => NaN)
+    @test NaNMath.argmin(x) === :z
+    @test NaNMath.argmax(x) === :x
+    @test NaNMath.argmin(identity, x) === argmin(identity, x)
+    @test NaNMath.argmax(identity, x) === argmax(identity, x)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -120,6 +120,12 @@ using Test
     @test NaNMath.findmax(identity, x) === (3, :x)
     @test NaNMath.findmin(-, x) === (-3, :x)
     @test NaNMath.findmax(-, x) === (1.0, :y)
+
+    x = Dict(:x => :a, :w => :b, :y => :c, :z => :d)
+    y = Dict(:a => 3, :b => 2, :c => -1.0, :d => NaN)
+    f = k -> y[k]
+    @test NaNMath.findmin(f, x) === (-1.0, :y)
+    @test NaNMath.findmax(f, x) === (3, :x)
 end
 
 @testset "argmin/argmax" begin
@@ -169,4 +175,10 @@ end
     @test NaNMath.argmax(x) === :x
     @test NaNMath.argmin(identity, x) === argmin(identity, x)
     @test NaNMath.argmax(identity, x) === argmax(identity, x)
+
+    x = (:a, :b, :c, :d)
+    y = Dict(:a => 3, :b => 2, :c => -1.0, :d => NaN)
+    f = k -> y[k]
+    @test NaNMath.argmin(f, x) === :c
+    @test NaNMath.argmax(f, x) === :a
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,3 +70,85 @@ using Test
 @test isnan(NaNMath.max(NaN, NaN))
 @test isnan(NaNMath.max(NaN))
 @test NaNMath.max(NaN, NaN, 0.0, 1.0) == 1.0
+
+@testset "findmin/findmax" begin
+    xvals = [
+        [1., 2., 3., 3., 1.],
+        [missing, missing],
+        [missing, 1.0],
+        [1.0, missing],
+        (1., 2, 3., 3, 1),
+    ]
+    @testset for x in xvals
+        @test NaNMath.findmin(x) === findmin(x)
+        @test NaNMath.findmin(identity, x) === findmin(identity, x)
+        @test NaNMath.findmin(sin, x) === findmin(sin, x)
+        @test NaNMath.findmax(x) === findmax(x)
+        @test NaNMath.findmax(identity, x) === findmax(identity, x)
+        @test NaNMath.findmax(sin, x) === findmax(sin, x)
+    end
+    x = [7, 7, NaN, 1, 1, NaN]
+    @test NaNMath.findmin(x) === (1.0, 4)
+    @test NaNMath.findmax(x) === (7.0, 1)
+    @test NaNMath.findmin(identity, x) === (1.0, 4)
+    @test NaNMath.findmax(identity, x) === (7.0, 1)
+    @test NaNMath.findmin(-, x) === (-7.0, 1)
+    @test NaNMath.findmax(-, x) === (-1.0, 4)
+
+    x = [NaN, NaN]
+    @test NaNMath.findmin(x) === (NaN, 1)
+    @test NaNMath.findmax(x) === (NaN, 1)
+    @test NaNMath.findmin(identity, x) === (NaN, 1)
+    @test NaNMath.findmax(identity, x) === (NaN, 1)
+    @test NaNMath.findmin(sin, x) === (NaN, 1)
+    @test NaNMath.findmax(sin, x) === (NaN, 1)
+
+    x = [3, missing, NaN, -1]
+    @test NaNMath.findmin(x) === (missing, 2)
+    @test NaNMath.findmax(x) === (missing, 2)
+    @test NaNMath.findmin(identity, x) === (missing, 2)
+    @test NaNMath.findmax(identity, x) === (missing, 2)
+    @test NaNMath.findmin(sin, x) === (missing, 2)
+    @test NaNMath.findmax(sin, x) === (missing, 2)
+end
+
+@testset "argmin/argmax" begin
+    xvals = [
+        [1., 2., 3., 3., 1.],
+        [missing, missing],
+        [missing, 1.0],
+        [1.0, missing],
+        (1., 2, 3., 3, 1),
+    ]
+    @testset for x in xvals
+        @test NaNMath.argmin(x) === argmin(x)
+        @test NaNMath.argmin(identity, x) === argmin(identity, x)
+        @test NaNMath.argmin(sin, x) === argmin(sin, x)
+        @test NaNMath.argmax(x) === argmax(x)
+        @test NaNMath.argmax(identity, x) === argmax(identity, x)
+        @test NaNMath.argmax(sin, x) === argmax(sin, x)
+    end
+    x = [7, 7, NaN, 1, 1, NaN]
+    @test NaNMath.argmin(x) === 4
+    @test NaNMath.argmax(x) === 1
+    @test NaNMath.argmin(identity, x) === 1.0
+    @test NaNMath.argmax(identity, x) === 7.0
+    @test NaNMath.argmin(-, x) === 7.0
+    @test NaNMath.argmax(-, x) === 1.0
+
+    x = [NaN, NaN]
+    @test NaNMath.argmin(x) === 1
+    @test NaNMath.argmax(x) === 1
+    @test NaNMath.argmin(identity, x) === NaN
+    @test NaNMath.argmax(identity, x) === NaN
+    @test NaNMath.argmin(-, x) === NaN
+    @test NaNMath.argmax(-, x) === NaN
+
+    x = [3, missing, NaN, -1]
+    @test NaNMath.argmin(x) === 2
+    @test NaNMath.argmax(x) === 2
+    @test NaNMath.argmin(identity, x) === missing
+    @test NaNMath.argmax(identity, x) === missing
+    @test NaNMath.argmin(-, x) === missing
+    @test NaNMath.argmax(-, x) === missing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,7 +81,7 @@ using Test
         (x=1, y=3, z=-4, w=-2),
         Dict(:a => 1.0, :b => 1.0, :d => 3.0, :c => 2.0),
     ]
-    @testset for x in xvals
+    VERSION ≥ v"1.7" && @testset for x in xvals
         @test NaNMath.findmin(x) === findmin(x)
         @test NaNMath.findmax(x) === findmax(x)
         @test NaNMath.findmin(identity, x) === findmin(identity, x)
@@ -138,7 +138,7 @@ end
         (x=1, y=3, z=-4, w=-2),
         Dict(:a => 1.0, :b => 1.0, :d => 3.0, :c => 2.0),
     ]
-    @testset for x in xvals
+    VERSION ≥ v"1.7" && @testset for x in xvals
         @test NaNMath.argmin(x) === argmin(x)
         @test NaNMath.argmax(x) === argmax(x)
         @test NaNMath.argmin(identity, x) === argmin(identity, x)
@@ -173,8 +173,10 @@ end
     x = Dict(:x => 3, :w => 2, :z => -1.0, :y => NaN)
     @test NaNMath.argmin(x) === :z
     @test NaNMath.argmax(x) === :x
-    @test NaNMath.argmin(identity, x) === argmin(identity, x)
-    @test NaNMath.argmax(identity, x) === argmax(identity, x)
+    if VERSION ≥ v"1.7"
+        @test NaNMath.argmin(identity, x) === argmin(identity, x)
+        @test NaNMath.argmax(identity, x) === argmax(identity, x)
+    end
 
     x = (:a, :b, :c, :d)
     y = Dict(:a => 3, :b => 2, :c => -1.0, :d => NaN)


### PR DESCRIPTION
This PR adds versions of `findmin`, `findmax`, `argmin` and `argmax` that ignore `NaN`s in the codomain. It does not include methods that take a `dims` keyword.

Fixes #31

A simple benchmark:
```julia
julia> using NaNMath, BenchmarkTools

julia> x = map(x -> x < 0.9 ? x : NaN, rand(1_000, 1_000));

julia> @btime findmax($x);
  1.914 ms (0 allocations: 0 bytes)

julia> @btime $(NaNMath.findmax)($x);
  2.809 ms (0 allocations: 0 bytes)

julia> @btime $(NaNMath.maximum)($x);
  2.100 ms (0 allocations: 0 bytes)

julia> @btime findmax(cos, $x);
  9.590 ms (0 allocations: 0 bytes)

julia> @btime $(NaNMath.findmax)(cos, $x);
  9.226 ms (0 allocations: 0 bytes)

julia> @btime argmax($x);
  1.915 ms (0 allocations: 0 bytes)

julia> @btime $(NaNMath.argmax)($x);
  2.725 ms (0 allocations: 0 bytes)

julia> @btime argmax(cos, $x);
  8.348 ms (0 allocations: 0 bytes)

julia> @btime $(NaNMath.argmax)(cos, $x);
  8.560 ms (0 allocations: 0 bytes)
```