### PR TITLE
Implement `findmin`, `findmax`, `argmin`, `argmax`

### DIFF
--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -351,4 +351,220 @@ for f in (:min, :max)
     @eval ($f)(a, b, c, xs...) = Base.afoldl($f, ($f)(($f)(a, b), c), xs...)
 end
 
+# The functions `findmin`, `findmax`, `argmin`, and `argmax` are supported 
+# to work correctly for the following iterable types:
+_valtype(x::AbstractArray{T}) where T<:AbstractFloat = eltype(x)
+_valtype(x::Tuple{Vararg{T} where T<:AbstractFloat})  = eltype(x)
+_valtype(x::NamedTuple{syms, <:Tuple{Vararg{T} where T<:AbstractFloat}}) where {syms} = eltype(x)
+_valtype(x::AbstractDict{K,T}) where {K,T<:AbstractFloat} = valtype(x)
+_valtype(x) = error(
+    "Iterables with value type AbstractFloat or its subtypes are supported.
+    The provided input type $(typeof(x)) is not.
+    Consider using the convert function before passing the iterable argument."
+
+)
+
+function _find_extreme(f,compare_op::Function, x)
+    result_index = 1 # Note: default index value.
+    result_value = convert(_valtype(x), NaN)
+
+    for (k, v) in pairs(x)
+        if !isnan(v)
+            if (isnan(result_value) || compare_op(f(v),f(result_value)))
+                result_index = k
+                result_value = v
+            end
+        end
+    end
+    return f(result_value), result_index
+end
+
+"""
+    NaNMath.findmin(f, domain) -> (f(x), index)
+
+    NaNMath.findmin(domain) -> (x, index)
+
+##### Args:
+* `f`: A function applied to the elements of `domain`; 
+  defaults to `identity` when `domain` is the only argument.
+* `domain`: A non-empty collection of floating point numbers such that
+  `f` is defined on elements of `domain`.
+
+##### Returns:
+* Returns a `Tuple` consisting of a value `f(x)` and the index of `x`
+  in `domain`, ignoring NaN's, such that `f(x)` is minimized.
+  If there are multiple minimal elements, then the first one will be returned.
+
+If `domain` is a `NamedTuple` or dictionary-like `AbstractDict` L,
+the function is applied to its values.  The returned index is a key `k`,
+such that `f(L[k])` is minimized.
+
+##### Examples:
+```julia
+julia> NaNMath.findmin([1., 1., 2., 2., NaN])
+(1.0, 1)
+
+julia> NaNMath.findmin(-, [1., 1., 2., 2., NaN])
+(-2.0, 3)
+
+julia> NaNMath.findmin(abs, Dict(:x => 3.0, :w => -2.2, :y => -3.0, :z => NaN))
+(2.2, :w)
+```
+"""
+function findmin end
+findmin(f,x) = _find_extreme(f,<,x)
+findmin(x) = findmin(identity,x)
+
+"""
+    NaNMath.findmax(f, domain) -> (f(x), index)
+
+    NaNMath.findmax(domain) -> (x, index)
+
+##### Args:
+* `f`: A function applied to the elements of `domain`; 
+  defaults to `identity` when `domain` is the only argument.
+* `domain`: A non-empty collection of floating point numbers such that
+  `f` is defined on elements of `domain`.
+
+##### Returns:
+* Returns a `Tuple` consisting of a value `f(x)` and the index of `x`
+  in `domain`, ignoring NaN's, such that `f(x)` is maximized.
+  If there are multiple maximal elements, then the first one will be returned.
+
+If `domain` is a `NamedTuple` or dictionary-like `AbstractDict` L,
+the function `f` is applied to its values.  The returned index is a key `k`,
+such that `f(L[k])` is maximized.
+
+##### Examples:
+```julia
+julia> NaNMath.findmax([1., 1., 2., 2., NaN])
+(2.0, 3)
+
+julia> NaNMath.findmax(-, [1., 1., 2., 2., NaN])
+(-1.0, 1)
+
+julia> NaNMath.findmax(abs, Dict(:x => 3.0, :w => -2.2, :y => -3.0, :z => NaN))
+(3.0, :y)
+```
+"""
+function findmax end
+findmax(f,x) = _find_extreme(f,>,x)
+findmax(x) = findmax(identity,x) 
+
+"""
+    NaNMath.argmin(f, domain) -> x
+
+##### Args:
+* `f`: A function applied to the elements of `domain`; 
+  defaults to `identity` when `domain` is the only argument.
+* `domain`: A non-empty collection of floating point numbers such that
+  `f` is defined on elements of `domain`.
+
+##### Returns:
+* Returns a value `x` in `domain`, ignoring NaN's, for which `f(x)` is minimized.
+  If there are multiple minimal values for `f(x)`, then the first one will be returned.
+
+If `domain` is a `NamedTuple` or dictionary-like `AbstractDict` L,
+the function is applied to its values.  The returned value is `L[k]` for some key `k`
+such that `f(L[k])` is minimal.
+
+##### Examples:
+```julia
+julia> NaNMath.argmin(abs, [1., -1., -2., 2., NaN])
+1.0
+
+julia> NaNMath.argmin(identity, [7, 1, 1, NaN])
+1.0
+```
+
+julia> NaNMath.argmin(exp,Dict("x" => 1.0, "y" => -1.2, "z" => NaN))
+-1.2
+
+───────────────────────────────────────────────────────────
+
+    NaNMath.argmin(itr) -> key
+
+##### Args:
+* `itr`: A non-empty iterable of floating point numbers.
+
+##### Returns:
+* Returns the index or key of the minimal element in `itr`, ignoring NaN's.
+  If there are multiple minimal elements, then the first one will be returned.
+
+If `itr` is a `NamedTuple` or dictionary-like `AbstractDict` L, the returned index is a key `k`,
+such that `f(L[k])` is minimal.
+
+##### Examples:
+```julia
+julia> NaNMath.argmin([7, 1, 1, NaN])
+2
+
+julia> NaNMath.argmin([1.0 2; 3 NaN])
+CartesianIndex(1, 1)
+
+julia> NaNMath.argmin(Dict("x" => 1.0, "y" => -1.2, "z" => NaN))
+"y"
+```
+"""
+function argmin end
+argmin(f,x) = getindex(x,findmin(f,x)[2])
+argmin(x) = findmin(identity,x)[2]
+
+"""
+    NaNMath.argmax(f, domain) -> x
+
+##### Args:
+* `f`: A function applied to the elements of `domain`; 
+  defaults to `identity` when `domain` is the only argument.
+* `domain`: A non-empty collection of floating point numbers such that
+  `f` is defined on elements of `domain`.
+
+##### Returns:
+* Returns a value `x` in `domain`, ignoring NaN's, for which `f(x)` is maximized.
+  If there are multiple maximal values for `f(x)`, then the first one will be returned.
+
+If `domain` is a `NamedTuple` or dictionary-like `AbstractDict` L,
+the function is applied to its values.  The returned value is `L[k]` for some key `k`
+such that `f(L[k])` is maximal.
+
+##### Examples:
+```julia
+julia> NaNMath.argmax(abs, [1., -1., -2., NaN])
+-2.0
+
+julia> NaNMath.argmax(identity, [7, 1, 1, NaN])
+7.0
+```
+
+───────────────────────────────────────────────────────────
+
+    NaNMath.argmax(itr) -> key
+
+##### Args:
+* `itr`: A non-empty iterable of floating point numbers.
+
+##### Returns:
+* Returns the index or key of the maximal element in `itr`, ignoring NaN's.
+  If there are multiple maximal elements, then the first one will be returned.
+
+If `itr` is a `NamedTuple` or dictionary-like `AbstractDict` L, the returned index is a key `k`,
+such that `f(L[k])` is maximal.
+
+
+##### Examples:
+```julia
+julia> NaNMath.argmax([7, 1, 1, NaN])
+1
+
+julia> NaNMath.argmax([1.0 2; 3 NaN])
+CartesianIndex(2, 1)
+
+julia> NaNMath.argmax(Dict("x" => 1.0, "y" => -1.2, "z" => NaN))
+"x"
+```
+"""
+function argmax end
+argmax(x) = findmax(identity,x)[2]
+argmax(f,x) = getindex(x,findmax(f,x)[2])
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,3 +70,136 @@ using Test
 @test isnan(NaNMath.max(NaN, NaN))
 @test isnan(NaNMath.max(NaN))
 @test NaNMath.max(NaN, NaN, 0.0, 1.0) == 1.0
+
+## Based on https://github.com/sethaxen/NaNMath.jl/blob/41b3e7edd9dd4cb6c2873abf6e0d90acf43138ec/test/runtests.jl
+@testset "findmin/findmax" begin
+    if VERSION ≥ v"1.7"
+        xvals = [
+            [1., 2., 3., 3., 1.],
+            (1., 2., 3., 3., .1),
+            (1f0, 2f0, 3f0, -1f0),
+            (x=1.0, y=3f0, z=-4.0, w=-2f0),
+            Dict(:a => 1.0, :b => 1.0, :d => 3.0, :c => 2.0),
+        ]
+        @testset for x in xvals
+            @test NaNMath.findmin(x) === findmin(x)
+            @test NaNMath.findmax(x) === findmax(x)
+            @test NaNMath.findmin(identity, x) === findmin(identity, x)
+            @test NaNMath.findmax(identity, x) === findmax(identity, x)
+            @test NaNMath.findmin(sin, x) === findmin(sin, x)
+            @test NaNMath.findmax(sin, x) === findmax(sin, x)
+        end
+    end
+
+    x = [7, 7, NaN, 1, 1, NaN]
+    @test NaNMath.findmin(x) === (1.0, 4)
+    @test NaNMath.findmax(x) === (7.0, 1)
+    @test NaNMath.findmin(identity, x) === (1.0, 4)
+    @test NaNMath.findmax(identity, x) === (7.0, 1)
+    @test NaNMath.findmin(-, x) === (-7.0, 1)
+    @test NaNMath.findmax(-, x) === (-1.0, 4)
+
+    x = [NaN, NaN]
+    @test NaNMath.findmin(x) === (NaN, 1)
+    @test NaNMath.findmax(x) === (NaN, 1)
+    @test NaNMath.findmin(identity, x) === (NaN, 1)
+    @test NaNMath.findmax(identity, x) === (NaN, 1)
+    @test NaNMath.findmin(sin, x) === (NaN, 1)
+    @test NaNMath.findmax(sin, x) === (NaN, 1)
+
+    x = Dict(:a => 1.0, :b => 1 + 2im, :d => 3.0, :c => 2.0)
+    @test_throws ErrorException NaNMath.findmin(x)
+    @test_throws ErrorException NaNMath.findmax(x)
+
+    x = [3, missing, NaN, -1]
+    @test_throws ErrorException NaNMath.findmin(x)
+
+    x = Dict('a' => 1.0, missing => NaN, 'c' => 2.0)
+    @test NaNMath.findmin(x) === (1.0, 'a')
+    @test NaNMath.findmax(x) === (2.0, 'c')
+
+    x = Dict(:x => 3.0, :w => 2f0, :y => -1.0, :z => NaN)
+    @test NaNMath.findmin(x) === (-1.0, :y)
+    @test NaNMath.findmax(x) === (3.0, :x)
+    @test NaNMath.findmin(identity, x) === (-1.0, :y)
+    @test NaNMath.findmax(identity, x) === (3.0, :x)
+    @test NaNMath.findmin(-, x) === (-3.0, :x)
+    @test NaNMath.findmax(-, x) === (1.0, :y)
+    @test NaNMath.findmin(exp, x) === (exp(-1.0), :y)
+    @test NaNMath.findmax(exp, x) === (exp(3.0), :x)
+
+    x = (x=1.0, y=NaN, z=NaN, w=-2.0)
+    @test NaNMath.findmin(x) === (-2.0, :w)
+    @test NaNMath.findmax(x) === (1.0, :x)
+    @test NaNMath.findmin(-,x) === (-1.0, :x)
+    @test NaNMath.findmax(-,x) === (2.0, :w)
+
+    x = [2.0 3.0; 2.0 -1.0]
+    @test NaNMath.findmin(x) === (-1.0, CartesianIndex(2, 2))
+    @test NaNMath.findmax(x) === (3.0, CartesianIndex(1, 2))
+    @test NaNMath.findmin(exp,x) === (exp(-1), CartesianIndex(2, 2))
+    @test NaNMath.findmax(exp,x) === (exp(3.0), CartesianIndex(1, 2))
+end
+
+@testset "argmin/argmax" begin
+    if VERSION ≥ v"1.7"
+        xvals = [
+            [1., 2., 4., 3., 1.],
+            (1., 2., 4., 3., .1),
+            (1f0, 2f0, 3f0, -1f0),
+            (x=1.0, y=3f0, z=-4.0, w=-2f0),
+            Dict(:a => 1.0, :b => 1.0, :d => 3.0, :c => 2.0),
+        ]    
+        @testset for x in xvals
+            @test NaNMath.argmin(x) === argmin(x)
+            @test NaNMath.argmax(x) === argmax(x)
+            x isa Dict || @test NaNMath.argmin(identity, x) === argmin(identity, x)
+            x isa Dict || @test NaNMath.argmax(identity, x) === argmax(identity, x)
+            x isa Dict || @test NaNMath.argmin(sin, x) === argmin(sin, x)
+            x isa Dict || @test NaNMath.argmax(sin, x) === argmax(sin, x)
+        end
+    end
+    x = [7, 7, NaN, 1, 1, NaN]
+    @test NaNMath.argmin(x) === 4
+    @test NaNMath.argmax(x) === 1
+    @test NaNMath.argmin(identity, x) === 1.0
+    @test NaNMath.argmax(identity, x) === 7.0
+    @test NaNMath.argmin(-, x) === 7.0
+    @test NaNMath.argmax(-, x) === 1.0
+
+    x = [NaN, NaN]
+    @test NaNMath.argmin(x) === 1
+    @test NaNMath.argmax(x) === 1
+    @test NaNMath.argmin(identity, x) === NaN
+    @test NaNMath.argmax(identity, x) === NaN
+    @test NaNMath.argmin(-, x) === NaN
+    @test NaNMath.argmax(-, x) === NaN
+
+    x = [3, missing, NaN, -1]
+    @test_throws ErrorException NaNMath.argmin(x)
+    @test_throws ErrorException NaNMath.argmax(x)
+
+    x = Dict('a' => 1.0, missing => NaN, 'c' => 2.0)
+    @test NaNMath.argmin(x) === 'a'
+    @test NaNMath.argmax(x) === 'c'
+
+    x = Dict(:v => NaN, :w => 2.1f0, :x => 3.1, :z => -1.0, :y => NaN)
+    @test NaNMath.argmin(x) === :z
+    @test NaNMath.argmax(x) === :x
+    @test NaNMath.argmin(-, x) === 3.1
+    @test NaNMath.argmax(-, x) === -1.0
+    @test NaNMath.argmin(exp, x) === -1.0
+    @test NaNMath.argmax(exp, x) === 3.1
+
+    x = (x=1.1, y=NaN, z=NaN, w=-2.3)
+    @test NaNMath.argmin(x) === :w
+    @test NaNMath.argmax(x) === :x
+    @test NaNMath.argmin(exp, x) === -2.3
+    @test NaNMath.argmax(exp, x) === 1.1
+
+    x = [2.0 3.0; 2.0 -1.0]
+    @test NaNMath.argmin(x) === CartesianIndex(2, 2)
+    @test NaNMath.argmax(x) === CartesianIndex(1, 2)
+    @test NaNMath.argmin(exp,x) === -1.0
+    @test NaNMath.argmax(exp,x) === 3.0
+end


### PR DESCRIPTION
This is an attempt at building from #53 (and addressing issue #31) that aims to follow the existing style of code and docstrings of NaNMath. I'm going for clarity in both rather than generality or performance; in fact, deliberately restricting dispatch to AbstractFloat types. A lot of credit due on this to @sethaxen since I've adapted his PR tests and docstrings.