### PR TITLE
Add safe fallbacks of `pow` for integer exponents and complex numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "NaNMath"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 repo = "https://github.com/JuliaMath/NaNMath.jl.git"
 authors = ["Miles Lubin"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 OpenLibm_jll = "05823500-19ac-5b8b-9628-191a04bc5112"

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -25,6 +25,10 @@ pow(x::Float32, y::Float32) = ccall((:powf,libm), Float32, (Float32,Float32), x,
 pow(x::Number, y::Number) = pow(promote(x, y)...)
 pow(x::T, y::T) where {T<:Number} = pow(float(x), float(y))
 
+# The following combinations are safe, so we can fall back to ^
+pow(x::Number, y::Integer) = x^y
+pow(x::Complex, y::Complex) = x^y
+
 """
 NaNMath.sum(A)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,6 @@ using Test
 @test isnan(NaNMath.pow(-1.5f0,2.3f0))
 @test isnan(NaNMath.pow(-1.5,2.3f0))
 @test isnan(NaNMath.pow(-1.5f0,2.3))
-@test NaNMath.pow(-1,2) isa Float64
 @test NaNMath.pow(-1.5f0,2) isa Float32
 @test NaNMath.pow(-1.5f0,2//1) isa Float32
 @test NaNMath.pow(-1.5f0,2.3f0) isa Float32
@@ -16,6 +15,11 @@ using Test
 @test NaNMath.pow(-1.5,2//1) isa Float64
 @test NaNMath.pow(-1.5,2.3f0) isa Float64
 @test NaNMath.pow(-1.5,2.3) isa Float64
+@test NaNMath.pow(-1,2) === 1
+@test NaNMath.pow(2,2) === 4
+@test NaNMath.pow(1.0, 1.0+im) === 1.0 + 0.0im
+@test NaNMath.pow(1.0+im, 1) === 1.0 + 1.0im
+@test NaNMath.pow(1.0+im, 1.0) === 1.0 + 1.0im
 @test isnan(NaNMath.sqrt(-5))
 @test NaNMath.sqrt(5) == Base.sqrt(5)
 @test isnan(NaNMath.sqrt(-3.2f0)) && NaNMath.sqrt(-3.2f0) isa Float32


### PR DESCRIPTION
This PR fixes #76 and the following unfortunate behaviour on the master branch:

```julia
julia> using NaNMath

julia> -1^2
1

julia> NaNMath.pow(-1, 2)
1.0

julia> 2^2
4

julia> NaNMath.pow(2, 2)
4.0
```