### PR TITLE
Fix `Vararg` issue

### DIFF
--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -372,10 +372,10 @@ end
 
 # The functions `findmin`, `findmax`, `argmin`, and `argmax` are supported 
 # to work correctly for the following iterable types:
-_valtype(x::AbstractArray{T}) where T<:AbstractFloat = eltype(x)
-_valtype(x::Tuple{Vararg{T} where T<:AbstractFloat})  = eltype(x)
-_valtype(x::NamedTuple{syms, <:Tuple{Vararg{T} where T<:AbstractFloat}}) where {syms} = eltype(x)
-_valtype(x::AbstractDict{K,T}) where {K,T<:AbstractFloat} = valtype(x)
+_valtype(x::AbstractArray{<:AbstractFloat}) = eltype(x)
+_valtype(x::Tuple{Vararg{AbstractFloat}}) = eltype(x)
+_valtype(x::NamedTuple{<:Any, <:Tuple{Vararg{AbstractFloat}}}) = eltype(x)
+_valtype(x::AbstractDict{<:Any,<:AbstractFloat}) = valtype(x)
 _valtype(x) = error(
     "Iterables with value type AbstractFloat or its subtypes are supported.
     The provided input type $(typeof(x)) is not.


### PR DESCRIPTION
#53 introduced the following compiler warnings:

```julia
┌ NaNMath
│  WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
│  You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
│  WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
│  You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
└  
```

The PR fixes them.