### PR TITLE
fix: fix fallback for `lgamma`

### DIFF
--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -11,9 +11,7 @@ for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh,
             x === xf && throw(MethodError($f, (x,)))
             ($f)(xf)
         end
-        if $f !== :lgamma
-            ($f)(x) = (Base.$f)(x)
-        end
+        $(f !== :lgamma ? :(($f)(x) = (Base.$f)(x)) : :())
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,6 +223,7 @@ for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
           :log1p, :sqrt)
     @test @eval (NaNMath.$f)(x) == $f(x)
 end
+@test_throws MethodError NaNMath.lgamma(x)
 
 struct A end
 Base.isless(::A, ::A) = false


### PR DESCRIPTION
The interpolation syntax was incorrect, and evaluated to
```julia
if lgamma !== :lgamma
    lgamma(x) = Base.lgamma(x)
end
```

Which threw an `UndefVarError`.