### PR TITLE
Fix `NaNMath.acosh`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "NaNMath"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 repo = "https://github.com/JuliaMath/NaNMath.jl.git"
 authors = ["Miles Lubin"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 OpenLibm_jll = "05823500-19ac-5b8b-9628-191a04bc5112"

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -34,7 +34,7 @@ for f in (:asin, :acos, :atanh)
     end
 end
 function acosh(x::T) where T<:Union{Float16, Float32, Float64}
-    x < T(1) ? T(NaN) : acosh(x)
+    x < T(1) ? T(NaN) : Base.acosh(x)
 end
 
 for f in (:log, :log2, :log10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,3 +232,15 @@ for f in (:max, :min)
     @test @eval (NaNMath.$f)(y, y) == $f(y, y)
 end
 @test NaNMath.pow(x, x) == ^(x, x)
+
+@testset "acosh" begin
+    for T in (Float16, Float32, Float64)
+        y = @inferred(NaNMath.acosh(T(0.5)))
+        @test y isa T
+        @test isnan(y)
+        y = NaNMath.acosh(T(2.1))
+        @test y isa T
+        @test !isnan(y)
+        @test y === acosh(T(2.1))
+    end
+end


### PR DESCRIPTION
#85 broke `NaNMath.acosh`:

```julia
julia> NaNMath.acosh(2.1)
NaN
```

This causes downstream test failures in e.g. ForwardDiff and ReverseDiff. This PR fixes it.